### PR TITLE
保存が反映されないケースを修正

### DIFF
--- a/src/main/java/com/example/Attendance/web/user/UserController.java
+++ b/src/main/java/com/example/Attendance/web/user/UserController.java
@@ -59,8 +59,8 @@ public class UserController {
       return "user/index";
     }
 
-    // 勤怠データが入力されていなければ処理を終了する
-    if(lib.isEmptyDailyAttendanceData(form.getDailyAttendanceList())) {
+    // 未登録の月で勤怠データが入力されていなければ登録処理は行わない
+    if(!lib.canRegisterData(period, service, form.getDailyAttendanceList())) {
       ShowMonthlyAttendance ShowMonthlyAttendance = lib.setAttendanceData(service, period);
       model.addAttribute("data", ShowMonthlyAttendance);
       return "user/index";
@@ -98,8 +98,8 @@ public class UserController {
       return "user/index";
     }
 
-    // 勤怠データが入力されていなければ処理を終了する
-    if(lib.isEmptyDailyAttendanceData(form.getDailyAttendanceList())) {
+    // 未登録の月で勤怠データが入力されていなければ登録処理は行わない
+    if(!lib.canRegisterData(period, service, form.getDailyAttendanceList())) {
       ShowMonthlyAttendance ShowMonthlyAttendance = lib.setAttendanceData(service, period);
       model.addAttribute("data", ShowMonthlyAttendance);
       return "user/index";


### PR DESCRIPTION
改修前
一度登録を行った月の勤怠データをすべて空の状態で保存すると、保存処理が実行されない。

改修後
一度登録を行った月について、データが空の状態でも保存できるように修正した。